### PR TITLE
Fix test instructions, and refactor tests for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+__pycache__
+.cache
+build

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ You should see the string `<html><body>Hello World!</body></html>` printed out. 
 After installing pyxl:
 
 ```sh
-easy_install unittest2
-python pyxl_tests.py
+pip install pytest
+pytest tests
 ```
 
 ## How it works

--- a/tests/error_cases/if_1.py.txt
+++ b/tests/error_cases/if_1.py.txt
@@ -1,7 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         this is incorrect!
-         <else>bar</else>
-     </frag>)

--- a/tests/error_cases/if_2.py.txt
+++ b/tests/error_cases/if_2.py.txt
@@ -1,7 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         <else>bar</else>
-         <else>baz</else>
-     </frag>)

--- a/tests/error_cases/if_3.py.txt
+++ b/tests/error_cases/if_3.py.txt
@@ -1,6 +1,0 @@
-# coding: pyxl
-
-a = (<frag>
-         <if cond="{true}">foo</if>
-         <else><else>bar</else></else>
-     </frag>)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,23 +1,31 @@
+# coding: pyxl
+import pytest
+
 from pyxl.codec.register import pyxl_decode
-from pyxl.codec.tokenizer import PyxlParseError
 from pyxl.codec.parser import ParseError
 
-import os
+def test_malformed_if():
+    with pytest.raises(ParseError):
+        pyxl_decode("""
+            <frag>
+                <if cond="{true}">foo</if>
+                this is incorrect!
+                <else>bar</else>
+            </frag>""")
 
-error_cases_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                'error_cases')
+def test_multiple_else():
+    with pytest.raises(ParseError):
+        pyxl_decode("""
+            <frag>
+                <if cond="{true}">foo</if>
+                <else>bar</else>
+                <else>baz</else>
+             </frag>""")
 
-def _expect_failure(file_name):
-    path = os.path.join(error_cases_path, file_name)
-    try:
-        with open(path) as f:
-            print pyxl_decode(f.read())
-        assert False, "successfully decoded file %r" % file_name
-    except (PyxlParseError, ParseError):
-        pass
-
-def test_error_cases():
-    cases = os.listdir(error_cases_path)
-    for file_name in cases:
-        if file_name.endswith(".txt"):
-            yield (_expect_failure, file_name)
+def test_nested_else():
+    with pytest.raises(ParseError):
+        pyxl_decode("""
+            <frag>
+                <if cond="{true}">foo</if>
+                <else><else>bar</else></else>
+            </frag>""")

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,195 +1,190 @@
 #coding: pyxl
 import datetime
 
-from  unittest2 import TestCase
 from pyxl import html
 from pyxl import rss
 
-class RssTests(TestCase):
-    def test_decl(self):
-        decl = <rss.rss_decl_standalone />.to_string()
-        self.assertEqual(decl, u'<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>')
+def test_decl():
+    assert (str(<rss.rss_decl_standalone />)
+        == u'<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>')
 
-    def test_rss(self):
-        r = <rss.rss version="2.0" />.to_string()
-        self.assertEqual(r, u'<rss version="2.0"></rss>')
+def test_rss():
+    assert str(<rss.rss version="2.0" />) == u'<rss version="2.0"></rss>'
 
-    def test_channel(self):
-        c = (
+def test_channel():
+    assert str(
+        <rss.rss version="2.0">
+            <rss.channel />
+        </rss.rss>
+    ) == u'<rss version="2.0"><channel></channel></rss>'
+
+def test_channel_with_required_elements():
+    channel = (
+        <frag>
+            <rss.rss_decl_standalone />
             <rss.rss version="2.0">
-                <rss.channel />
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                </rss.channel>
             </rss.rss>
-        ).to_string()
+        </frag>
+    )
 
-        self.assertEqual(c, u'<rss version="2.0"><channel></channel></rss>')
-
-    def test_channel_with_required_elements(self):
-        channel = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
-
-        expected = '''
+    expected = '''
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+</channel>
 </rss>
 '''
-        expected = u''.join(l.strip() for l in expected.splitlines())
+    expected = u''.join(l.strip() for l in expected.splitlines())
 
-        self.assertEqual(channel.to_string(), expected)
+    assert str(channel) == expected
 
-    def test_channel_with_optional_elements(self):
-        channel = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                        <rss.ttl>60</rss.ttl>
-                        <rss.language>en-us</rss.language>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
+def test_channel_with_optional_elements():
+    channel = (
+        <frag>
+            <rss.rss_decl_standalone />
+            <rss.rss version="2.0">
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                    <rss.ttl>60</rss.ttl>
+                    <rss.language>en-us</rss.language>
+                </rss.channel>
+            </rss.rss>
+        </frag>
+    )
 
-        expected = """
+    expected = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-        <ttl>60</ttl>
-        <language>en-us</language>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+    <ttl>60</ttl>
+    <language>en-us</language>
+</channel>
 </rss>
 """
 
-        expected = u''.join(l.strip() for l in expected.splitlines())
-        self.assertEqual(channel.to_string(), expected)
+    expected = u''.join(l.strip() for l in expected.splitlines())
+    assert str(channel) == expected
 
-    def test_item_with_common_elements(self):
-        item = (
-            <rss.item>
-                <rss.title>Item Title</rss.title>
-                <rss.description>
-                    {html.rawhtml('<![CDATA[ ')}
-                    This is a really interesting description
-                    {html.rawhtml(']]>')}
-                </rss.description>
-                <rss.link>https://www.dropbox.com/somewhere</rss.link>
-            </rss.item>
-        )
+def test_item_with_common_elements():
+    item = (
+        <rss.item>
+            <rss.title>Item Title</rss.title>
+            <rss.description>
+                {html.rawhtml('<![CDATA[ ')}
+                This is a really interesting description
+                {html.rawhtml(']]>')}
+            </rss.description>
+            <rss.link>https://www.dropbox.com/somewhere</rss.link>
+        </rss.item>
+    )
 
-        expected = """
+    expected = """
 <item>
-    <title>Item Title</title>
-    <description><![CDATA[  This is a really interesting description ]]></description>
-    <link>https://www.dropbox.com/somewhere</link>
+<title>Item Title</title>
+<description><![CDATA[  This is a really interesting description ]]></description>
+<link>https://www.dropbox.com/somewhere</link>
 </item>
 """
 
-        expected = u''.join(l.strip() for l in expected.splitlines())
-        self.assertEqual(item.to_string(), expected)
+    expected = u''.join(l.strip() for l in expected.splitlines())
+    assert str(item) == expected
 
-    def test_guid(self):
-        self.assertEqual(<rss.guid>foo</rss.guid>.to_string(), u'<guid>foo</guid>')
-        self.assertEqual(<rss.guid is-perma-link="{False}">foo</rss.guid>.to_string(), 
-                         u'<guid isPermaLink="false">foo</guid>')
-        self.assertEqual(<rss.guid is-perma-link="{True}">foo</rss.guid>.to_string(),
-                         u'<guid isPermaLink="true">foo</guid>')
+def test_guid():
+    assert str(<rss.guid>foo</rss.guid>) == u'<guid>foo</guid>'
+    assert (str(<rss.guid is-perma-link="{False}">foo</rss.guid>)
+            == u'<guid isPermaLink="false">foo</guid>')
+    assert (str(<rss.guid is-perma-link="{True}">foo</rss.guid>)
+            == u'<guid isPermaLink="true">foo</guid>')
 
-    def test_date_elements(self):
-        dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
-        self.assertEqual(<rss.pubDate date="{dt}" />.to_string(),
-                         u'<pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>')
-        self.assertEqual(<rss.lastBuildDate date="{dt}" />.to_string(),
-                         u'<lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>')
+def test_date_elements():
+    dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
+    assert (str(<rss.pubDate date="{dt}" />)
+            == u'<pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>')
+    assert (str(<rss.lastBuildDate date="{dt}" />)
+            == u'<lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>')
 
-    def test_rss_document(self):
-        dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
-        dt2 = datetime.datetime(2013, 12, 18, 11, 54, 14)
-        doc = (
-            <frag>
-                <rss.rss_decl_standalone />
-                <rss.rss version="2.0">
-                    <rss.channel>
-                        <rss.title>A Title</rss.title>
-                        <rss.link>https://www.dropbox.com</rss.link>
-                        <rss.description>A detailed description</rss.description>
-                        <rss.ttl>60</rss.ttl>
-                        <rss.language>en-us</rss.language>
-                        <rss.lastBuildDate date="{dt}" />
-                        <rss.item>
-                            <rss.title>Item Title</rss.title>
-                            <rss.description>
-                                {html.rawhtml('<![CDATA[ ')}
-                                This is a really interesting description
-                                {html.rawhtml(']]>')}
-                            </rss.description>
-                            <rss.link>https://www.dropbox.com/somewhere</rss.link>
-                            <rss.pubDate date="{dt}" />
-                            <rss.guid is-perma-link="{False}">123456789</rss.guid>
-                        </rss.item>
-                        <rss.item>
-                            <rss.title>Another Item</rss.title>
-                            <rss.description>
-                                {html.rawhtml('<![CDATA[ ')}
-                                This is another really interesting description
-                                {html.rawhtml(']]>')}
-                            </rss.description>
-                            <rss.link>https://www.dropbox.com/nowhere</rss.link>
-                            <rss.pubDate date="{dt2}" />
-                            <rss.guid is-perma-link="{False}">ABCDEFGHIJ</rss.guid>
-                        </rss.item>
-                    </rss.channel>
-                </rss.rss>
-            </frag>
-        )
+def test_rss_document():
+    dt = datetime.datetime(2013, 12, 17, 23, 54, 14)
+    dt2 = datetime.datetime(2013, 12, 18, 11, 54, 14)
+    doc = (
+        <frag>
+            <rss.rss_decl_standalone />
+            <rss.rss version="2.0">
+                <rss.channel>
+                    <rss.title>A Title</rss.title>
+                    <rss.link>https://www.dropbox.com</rss.link>
+                    <rss.description>A detailed description</rss.description>
+                    <rss.ttl>60</rss.ttl>
+                    <rss.language>en-us</rss.language>
+                    <rss.lastBuildDate date="{dt}" />
+                    <rss.item>
+                        <rss.title>Item Title</rss.title>
+                        <rss.description>
+                            {html.rawhtml('<![CDATA[ ')}
+                            This is a really interesting description
+                            {html.rawhtml(']]>')}
+                        </rss.description>
+                        <rss.link>https://www.dropbox.com/somewhere</rss.link>
+                        <rss.pubDate date="{dt}" />
+                        <rss.guid is-perma-link="{False}">123456789</rss.guid>
+                    </rss.item>
+                    <rss.item>
+                        <rss.title>Another Item</rss.title>
+                        <rss.description>
+                            {html.rawhtml('<![CDATA[ ')}
+                            This is another really interesting description
+                            {html.rawhtml(']]>')}
+                        </rss.description>
+                        <rss.link>https://www.dropbox.com/nowhere</rss.link>
+                        <rss.pubDate date="{dt2}" />
+                        <rss.guid is-perma-link="{False}">ABCDEFGHIJ</rss.guid>
+                    </rss.item>
+                </rss.channel>
+            </rss.rss>
+        </frag>
+    )
 
-        expected = """
+    expected = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <rss version="2.0">
-    <channel>
-        <title>A Title</title>
-        <link>https://www.dropbox.com</link>
-        <description>A detailed description</description>
-        <ttl>60</ttl>
-        <language>en-us</language>
-        <lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>
-        <item>
-            <title>Item Title</title>
-            <description><![CDATA[  This is a really interesting description ]]></description>
-            <link>https://www.dropbox.com/somewhere</link>
-            <pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>
-            <guid isPermaLink="false">123456789</guid>
-        </item>
-        <item>
-            <title>Another Item</title>
-            <description><![CDATA[  This is another really interesting description ]]></description>
-            <link>https://www.dropbox.com/nowhere</link>
-            <pubDate>Wed, 18 Dec 2013 11:54:14 GMT</pubDate>
-            <guid isPermaLink="false">ABCDEFGHIJ</guid>
-        </item>
-    </channel>
+<channel>
+    <title>A Title</title>
+    <link>https://www.dropbox.com</link>
+    <description>A detailed description</description>
+    <ttl>60</ttl>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 17 Dec 2013 23:54:14 GMT</lastBuildDate>
+    <item>
+        <title>Item Title</title>
+        <description><![CDATA[  This is a really interesting description ]]></description>
+        <link>https://www.dropbox.com/somewhere</link>
+        <pubDate>Tue, 17 Dec 2013 23:54:14 GMT</pubDate>
+        <guid isPermaLink="false">123456789</guid>
+    </item>
+    <item>
+        <title>Another Item</title>
+        <description><![CDATA[  This is another really interesting description ]]></description>
+        <link>https://www.dropbox.com/nowhere</link>
+        <pubDate>Wed, 18 Dec 2013 11:54:14 GMT</pubDate>
+        <guid isPermaLink="false">ABCDEFGHIJ</guid>
+    </item>
+</channel>
 </rss>
 """
 
-        expected = ''.join(l.strip() for l in expected.splitlines())
+    expected = ''.join(l.strip() for l in expected.splitlines())
 
-        self.assertEqual(doc.to_string(), expected)
+    assert str(doc) ==  expected


### PR DESCRIPTION
There are a couple of problems with the instructions for running tests in the current project README:
1. `pyxl_tests.py` was renamed `tests\test_basic.py`
2. Since then, many more tests have been added and the README does not address how to run them all as a complete test suite.

It seems the newer tests have a different 'style' to the original `pyxl_tests.py`: the new tests use `pytest`-style, ie. plain asserts in functions rather than the `unittest2`-style consisting of `assertEqual` etc.

This suggests that the intended way of running the full test suite is with `pytest`.

This PR does the following:

a. Makes the test suite consistent with itself: changes any use of `unittest2` style testing to `pytest` style testing comprised of asserts in functions and removes any `unittest2` dependencies.

b. Adds instructions to the README for running the full test suite.
