### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ new_form = <form action="/submit" method="POST">{old_form.children("input")}</fo
 
 ### Attributes
 
-You can access any attribute of a tag as a member variable on the tag, or via the `attr(attr_name)` function. Setting attribute must happen via the `set_attr(attr_name, attr_value)` function i.e. do not set attrs by directly setting member variables. To access attributes that contain '-' (hypen) as a member variable, replace the hypen with '_' (underscore). For this reason, pyxl does not allow attributes with an underscore in their name. Here is an example that demonstrates all these principles:
+You can access any attribute of a tag as a member variable on the tag, or via the `attr(attr_name)` function. Setting attribute must happen via the `set_attr(attr_name, attr_value)` function i.e. do not set attrs by directly setting member variables. To access attributes that contain '-' (hyphen) as a member variable, replace the hyphen with '_' (underscore). For this reason, pyxl does not allow attributes with an underscore in their name. Here is an example that demonstrates all these principles:
 
 ```py
 fruit = <div data-text="tangerine" />

--- a/pyxl/codec/pytokenize.py
+++ b/pyxl/codec/pytokenize.py
@@ -283,7 +283,7 @@ def untokenize(iterable):
     Round-trip invariant for full input:
         Untokenized source will match input source exactly
 
-    Round-trip invariant for limited intput:
+    Round-trip invariant for limited input:
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
         newcode = untokenize(t1)
@@ -296,7 +296,7 @@ def untokenize(iterable):
 
 def generate_tokens(readline):
     """
-    The generate_tokens() generator requires one argment, readline, which
+    The generate_tokens() generator requires one argument, readline, which
     must be a callable object which provides the same interface as the
     readline() method of built-in file objects. Each call to the function
     should return one line of input as a string.  Alternately, readline

--- a/tests/test_whitespace_11.py
+++ b/tests/test_whitespace_11.py
@@ -2,7 +2,7 @@
 from pyxl import html
 
 def test():
-    # Presence of paretheses around html should not affect contents of tags. (In old pyxl,
+    # Presence of parentheses around html should not affect contents of tags. (In old pyxl,
     # this led to differences in whitespace handling.)
     assert str(get_frag1()) == str(get_frag2())
 


### PR DESCRIPTION
There are small typos in:
- README.md
- pyxl/codec/pytokenize.py
- tests/test_whitespace_11.py

Fixes:
- Should read `parentheses` rather than `paretheses`.
- Should read `input` rather than `intput`.
- Should read `hyphen` rather than `hypen`.
- Should read `argument` rather than `argment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md